### PR TITLE
Slew the commanded values, keep recalculation separate

### DIFF
--- a/libmtrmgr/include/mtrmgr.h
+++ b/libmtrmgr/include/mtrmgr.h
@@ -28,12 +28,13 @@
 */
 typedef struct {
   unsigned char port;         // port number of given motor
-  int pwm;                    // current pwm value
   int cmd;                    // commanded pwm value
-  unsigned long _lastUpdate;  // time (msec) of last commanded value
   float slewrate;             // caps the motor's acceleration
   char inverted;              // flips the motor output to avoid electrically flipping motors
   int(*recalculate)(int);     // used to scale the motor output for trueSpeed or other scalings
+
+  unsigned long _lastUpdate;  // time (msec) of last commanded value
+  int _prev;                  // past commanded value
 } Motor;
 
 /**

--- a/libmtrmgr/src/mtrmgr.c
+++ b/libmtrmgr/src/mtrmgr.c
@@ -44,7 +44,7 @@ static void _motorManagerTask(void *none)
 					  // the motorGet function gets a motor between channels 1-10. motor[index] goes from 0-9
             if (motorGet(i+1) != motor[i].cmd) // Motor has not been set to target
             {
-                int current = motorGet(i+1);
+                int current = motor[i]._prev;
                 int commanded = motor[i].cmd;
                 float slew = motor[i].slewrate;
                 int out = 0;
@@ -65,6 +65,7 @@ static void _motorManagerTask(void *none)
                       out = commanded;
                   }
 
+                  motor[i]._prev = out;
                   out = motor[i].recalculate(out);
                 }
 
@@ -104,6 +105,7 @@ void blrsMotorInit(int port, bool inverted, float slewrate, int (*recalculate)(i
     else {
       motor[port].recalculate = recalculate;
     }
+    motor[port]._prev = 0;
 }
 
 void motorManagerStop()


### PR DESCRIPTION
This implements a fix for Issue #1, where slewing would not work properly with a recalculate function. This commit resolves the issue by preserving the previously commanded value as `motor[port]._prev`, which previously was the unused `motor[port].pwm` value. Maintaining a record of the previous commanded value allows the Motor Manager to slew based solely on the commanded space, with no knowledge of the recalculation. In the example of a True Speed Linearizing recalculate function, this would ensure linear slewing to the output, even though the actual pwm values will not increase linearly.

An example implementation was this test:
```c
static int sgn(int val) {
    if (val > 0) return 1;
    else if (val < 0) return -1;
    return 0;
}

static int applyLinearMotor(int input) {
    static const unsigned int trueSpeed[128] =
    { 0,6,7,7,8,8,8,9,9,9,
    10,10,10,10,11,11,11,11,11,11,
    12,12,12,12,12,12,12,13,13,13,
    13,13,13,13,14,14,14,14,14,15,
    15,15,15,16,16,16,16,17,17,17,
    17,18,18,18,19,19,19,19,20,20,
    20,21,21,21,21,22,22,22,23,23,
    23,23,24,24,24,25,25,25,26,26,
    26,26,27,27,27,28,28,28,29,29,
    30,30,31,31,32,32,33,33,34,35,
    36,36,37,38,39,40,41,43,44,45,
    47,48,50,52,54,56,58,60,63,66,
    68,71,74,78,81,85,127,127 };

    int output = trueSpeed[abs(input)] * sgn(input);

    return output;
}

void operatorControl() {
	motorManagerInit();
	delay(100);
        blrsMotorInit(1, false, 0.5f, applyLinearMotor);
        blrsMotorSet(1, 127, false);
	while (true) {
		delay(20);
	}
}
```

Which yielded the following output:
```
prev: 0    out: 10
prev: 10    out: 12
prev: 20    out: 13
prev: 30    out: 15
prev: 40    out: 17
prev: 50    out: 20
prev: 60    out: 23
prev: 70    out: 26
prev: 80    out: 30
prev: 90    out: 36
prev: 100    out: 47
prev: 110    out: 68
prev: 120    out: 127
```

where `prev` is the `motor[port].prev` value, and `out` is the recalculated pwm value that is actually being sent to the motor.