### PR TITLE
Record _prev 

### DIFF
--- a/libmtrmgr/src/mtrmgr.c
+++ b/libmtrmgr/src/mtrmgr.c
@@ -119,6 +119,7 @@ bool blrsMotorSet(int port, int commanded, bool immediate) {
 			return false;
 		}
 		motorSet(port + 1, commanded * motor[port].inverted);
+		motor[port]._prev = commanded * motor[port].inverted;
 		mutexGive(mutex[port]);
 	}
 	motor[port].cmd = commanded * motor[port].inverted;


### PR DESCRIPTION
In the recent update which added the saving of _prev, and using that value for slew calculations, a bug was introduced that broke blrsMotorSet when used with immediate == true.

With the bug, say you were to blrsMotorSet(1, 127, true); and _prev is 80, the motor will immediately be set to 127, and then the task would set it to 80 + slew.

This fixes it by recording _prev when an immediate set is made.