### PR TITLE
libFBC bugfixes

### DIFF
--- a/libfbc/include/fbc.h
+++ b/libfbc/include/fbc.h
@@ -66,12 +66,16 @@ typedef struct fbc fbc_t; // predefine fbc_t for use inside fbc_t
 /**
  * @brief a simple stall detection algorithm
  *
+ * This stall detection algorithm looks for unexpectedly low movement for a given output, indicating that the robot
+ * is experiencing significant enough resistance that it may cause a stall. This function pointer can be given
+ * to the fbcInit function, or you can write your own stall detection function if you prefer.
+ *
  * @param fbc
  *        A pointer to a feedback controller
  *
  * @returns true if the controller is stalled, false otherwise
  */
- bool fbcStallDetect(fbc_t* fbc);
+extern bool (*fbcStallDetect)(fbc_t* fbc);
 
 /**
  * @brief Initializes a barebones feedback controller without the actual controller. Use an auxiliary function

--- a/libfbc/src/fbc.c
+++ b/libfbc/src/fbc.c
@@ -29,7 +29,7 @@ static bool _fbcStallDetect(fbc_t* fbc) {
 	unsigned int minCount = fbc->acceptableConfidence;
 	unsigned int delta = abs(fbc->sense() - _prev);
 
-	if (fbc->output == fbc->neg_deadband || fbc->output == fbc->pos_deadband) {
+	if (fbc->output == fbc->neg_deadband || fbc->output == fbc->pos_deadband || fbc->output == 0) {
 		_count = 0;
 		return false;
 	}

--- a/libfbc/src/fbc.c
+++ b/libfbc/src/fbc.c
@@ -26,7 +26,7 @@ static unsigned int _count = 0;
 static bool _fbcStallDetect(fbc_t* fbc) {
 	unsigned int minStuck = fbc->acceptableTolerance >> 3;
 	if (minStuck < 1) minStuck = 1;
-	unsigned int minCount = fbc->acceptableConfidence;
+	unsigned int countUntilStall = fbc->acceptableConfidence;
 	unsigned int delta = abs(fbc->sense() - _prev);
 
 	if (fbc->output == fbc->neg_deadband || fbc->output == fbc->pos_deadband || fbc->output == 0) {
@@ -41,7 +41,7 @@ static bool _fbcStallDetect(fbc_t* fbc) {
 
 	_prev = fbc->sense();
 
-	bool stall = _count > minCount;
+	bool stall = _count > countUntilStall;
 	if (stall) {
 		_count = 0;
 		_prev = 0;

--- a/libfbc/src/fbc.c
+++ b/libfbc/src/fbc.c
@@ -114,6 +114,7 @@ int fbcGenerateOutput(fbc_t * fbc) {
 		fbc->_confidence = 0;
 
 	fbc->_prevExecution = CUR_TIME();
+	fbc->output = out;
 	return out;
 }
 


### PR DESCRIPTION
Fix indentation issues, compilation issues with `fbcStallDetect` and precompiled binaries, and the computation of the `fbcStallDetect` function.